### PR TITLE
Add authentication for private or members-only posts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "ammonia"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,6 +143,17 @@ name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
+name = "async-trait"
+version = "0.1.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+]
 
 [[package]]
 name = "autocfg"
@@ -252,6 +269,42 @@ name = "bytes"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+
+[[package]]
+name = "cached"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9718806c4a2fe9e8a56fd736f97b340dd10ed1be8ed733ed50449f351dc33cae"
+dependencies = [
+ "ahash 0.8.11",
+ "async-trait",
+ "cached_proc_macro",
+ "cached_proc_macro_types",
+ "futures",
+ "hashbrown 0.14.3",
+ "once_cell",
+ "thiserror",
+ "tokio",
+ "web-time",
+]
+
+[[package]]
+name = "cached_proc_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f42a145ed2d10dce2191e1dcf30cfccfea9026660e143662ba5eec4017d5daa"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+]
+
+[[package]]
+name = "cached_proc_macro_types"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 
 [[package]]
 name = "cc"
@@ -482,6 +535,41 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
+ "quote",
+ "syn 2.0.60",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.60",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core",
  "quote",
  "syn 2.0.60",
 ]
@@ -731,12 +819,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -744,6 +847,12 @@ name = "futures-core"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-sink"
@@ -764,6 +873,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-core",
+ "futures-sink",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
@@ -837,6 +947,7 @@ name = "glowpub"
 version = "0.1.0"
 dependencies = [
  "ammonia",
+ "cached",
  "chrono",
  "clap",
  "cssparser 0.33.0",
@@ -911,6 +1022,10 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+dependencies = [
+ "ahash 0.8.11",
+ "allocator-api2",
+]
 
 [[package]]
 name = "heck"
@@ -1065,6 +1180,12 @@ checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -1422,9 +1543,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "openssl"
@@ -2995,6 +3116,16 @@ name = "web-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,12 +51,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
 name = "ammonia"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,17 +137,6 @@ name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
-
-[[package]]
-name = "async-trait"
-version = "0.1.85"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.60",
-]
 
 [[package]]
 name = "autocfg"
@@ -269,42 +252,6 @@ name = "bytes"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
-
-[[package]]
-name = "cached"
-version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9718806c4a2fe9e8a56fd736f97b340dd10ed1be8ed733ed50449f351dc33cae"
-dependencies = [
- "ahash 0.8.11",
- "async-trait",
- "cached_proc_macro",
- "cached_proc_macro_types",
- "futures",
- "hashbrown 0.14.3",
- "once_cell",
- "thiserror",
- "tokio",
- "web-time",
-]
-
-[[package]]
-name = "cached_proc_macro"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f42a145ed2d10dce2191e1dcf30cfccfea9026660e143662ba5eec4017d5daa"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn 2.0.60",
-]
-
-[[package]]
-name = "cached_proc_macro_types"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 
 [[package]]
 name = "cc"
@@ -535,41 +482,6 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
- "quote",
- "syn 2.0.60",
-]
-
-[[package]]
-name = "darling"
-version = "0.20.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.60",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.20.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
-dependencies = [
- "darling_core",
  "quote",
  "syn 2.0.60",
 ]
@@ -819,27 +731,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -847,12 +744,6 @@ name = "futures-core"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
-
-[[package]]
-name = "futures-io"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-sink"
@@ -873,7 +764,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-core",
- "futures-sink",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
@@ -947,7 +837,6 @@ name = "glowpub"
 version = "0.1.0"
 dependencies = [
  "ammonia",
- "cached",
  "chrono",
  "clap",
  "cssparser 0.33.0",
@@ -1022,10 +911,6 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
-dependencies = [
- "ahash 0.8.11",
- "allocator-api2",
-]
 
 [[package]]
 name = "heck"
@@ -1180,12 +1065,6 @@ checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
 ]
-
-[[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -3116,16 +2995,6 @@ name = "web-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -856,6 +856,7 @@ dependencies = [
  "regex",
  "reqwest",
  "resvg",
+ "rpassword",
  "serde",
  "serde_json",
  "sha2",
@@ -2066,6 +2067,27 @@ name = "roxmltree"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cd14fd5e3b777a7422cca79358c57a8f6e3a703d9ac187448d0daf220c2407f"
+
+[[package]]
+name = "rpassword"
+version = "7.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80472be3c897911d0137b2d2b9055faf6eeac5b14e324073d83bc17b191d7e3f"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c247d24e63230cdb56463ae328478bd5eac8b8faa8c69461a77e8e323afac90e"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "rustc-demangle"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "ammonia"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,6 +143,17 @@ name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
+name = "async-trait"
+version = "0.1.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+]
 
 [[package]]
 name = "autocfg"
@@ -252,6 +269,42 @@ name = "bytes"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+
+[[package]]
+name = "cached"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9718806c4a2fe9e8a56fd736f97b340dd10ed1be8ed733ed50449f351dc33cae"
+dependencies = [
+ "ahash 0.8.11",
+ "async-trait",
+ "cached_proc_macro",
+ "cached_proc_macro_types",
+ "futures",
+ "hashbrown 0.14.3",
+ "once_cell",
+ "thiserror",
+ "tokio",
+ "web-time",
+]
+
+[[package]]
+name = "cached_proc_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f42a145ed2d10dce2191e1dcf30cfccfea9026660e143662ba5eec4017d5daa"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+]
+
+[[package]]
+name = "cached_proc_macro_types"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 
 [[package]]
 name = "cc"
@@ -482,6 +535,41 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
+ "quote",
+ "syn 2.0.60",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.60",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core",
  "quote",
  "syn 2.0.60",
 ]
@@ -731,12 +819,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -744,6 +847,12 @@ name = "futures-core"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-sink"
@@ -764,6 +873,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-core",
+ "futures-sink",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
@@ -837,6 +947,7 @@ name = "glowpub"
 version = "0.1.0"
 dependencies = [
  "ammonia",
+ "cached",
  "chrono",
  "clap",
  "cssparser 0.33.0",
@@ -911,6 +1022,10 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+dependencies = [
+ "ahash 0.8.11",
+ "allocator-api2",
+]
 
 [[package]]
 name = "heck"
@@ -1065,6 +1180,12 @@ checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -2995,6 +3116,16 @@ name = "web-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,12 +51,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
 name = "ammonia"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,17 +137,6 @@ name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
-
-[[package]]
-name = "async-trait"
-version = "0.1.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.60",
-]
 
 [[package]]
 name = "autocfg"
@@ -269,42 +252,6 @@ name = "bytes"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
-
-[[package]]
-name = "cached"
-version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9718806c4a2fe9e8a56fd736f97b340dd10ed1be8ed733ed50449f351dc33cae"
-dependencies = [
- "ahash 0.8.11",
- "async-trait",
- "cached_proc_macro",
- "cached_proc_macro_types",
- "futures",
- "hashbrown 0.14.3",
- "once_cell",
- "thiserror",
- "tokio",
- "web-time",
-]
-
-[[package]]
-name = "cached_proc_macro"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f42a145ed2d10dce2191e1dcf30cfccfea9026660e143662ba5eec4017d5daa"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn 2.0.60",
-]
-
-[[package]]
-name = "cached_proc_macro_types"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 
 [[package]]
 name = "cc"
@@ -535,41 +482,6 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
- "quote",
- "syn 2.0.60",
-]
-
-[[package]]
-name = "darling"
-version = "0.20.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.60",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.20.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
-dependencies = [
- "darling_core",
  "quote",
  "syn 2.0.60",
 ]
@@ -819,27 +731,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -847,12 +744,6 @@ name = "futures-core"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
-
-[[package]]
-name = "futures-io"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-sink"
@@ -873,7 +764,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-core",
- "futures-sink",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
@@ -947,7 +837,6 @@ name = "glowpub"
 version = "0.1.0"
 dependencies = [
  "ammonia",
- "cached",
  "chrono",
  "clap",
  "cssparser 0.33.0",
@@ -1022,10 +911,6 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
-dependencies = [
- "ahash 0.8.11",
- "allocator-api2",
-]
 
 [[package]]
 name = "heck"
@@ -1180,12 +1065,6 @@ checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
 ]
-
-[[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -3116,16 +2995,6 @@ name = "web-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,4 @@ image = { version = "0.25", default-features = false, features = ["bmp", "gif", 
 clap = { version = "4", features = ["derive"] }
 simple_logger = "4"
 slug = "0.1"
+cached = { version = "0.54.0", features = ["async"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,4 +41,3 @@ image = { version = "0.25", default-features = false, features = ["bmp", "gif", 
 clap = { version = "4", features = ["derive"] }
 simple_logger = "4"
 slug = "0.1"
-cached = { version = "0.54.0", features = ["async"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,4 @@ image = { version = "0.25", default-features = false, features = ["bmp", "gif", 
 clap = { version = "4", features = ["derive"] }
 simple_logger = "4"
 slug = "0.1"
+rpassword = "7.3.1"

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -9,6 +9,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use crate::{
     types::{BoardInPost, Section, User},
     Board, Post, Reply,
+    utils::request_get
 };
 
 const GLOWFIC_API_V1: &str = "https://www.glowfic.com/api/v1";
@@ -147,7 +148,7 @@ pub(crate) async fn get_glowfic<T>(
 where
     T: DeserializeOwned,
 {
-    let response = retry(5, || reqwest::get(url)).await?;
+    let response = retry(5, || request_get(url)).await?;
     let parsed: GlowficResponse<T> = response.json().await?;
 
     Ok(parsed.into_result())

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -8,8 +8,8 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use crate::{
     types::{BoardInPost, Section, User},
+    utils::http_client,
     Board, Post, Reply,
-    utils::request_get
 };
 
 const GLOWFIC_API_V1: &str = "https://www.glowfic.com/api/v1";
@@ -148,7 +148,7 @@ pub(crate) async fn get_glowfic<T>(
 where
     T: DeserializeOwned,
 {
-    let response = retry(5, || request_get(url)).await?;
+    let response = retry(5, || http_client().get(url).send()).await?;
     let parsed: GlowficResponse<T> = response.json().await?;
 
     Ok(parsed.into_result())

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,15 +1,18 @@
 #[cfg(test)]
 mod tests;
 
-use std::{future::Future, time::Duration};
+use std::{future::Future, io, time::Duration, error::Error};
 
 use chrono::{DateTime, Utc};
+use reqwest::{header::{HeaderMap, HeaderValue, InvalidHeaderValue}, StatusCode};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
+use cached::proc_macro::once;
+
 use crate::{
-    types::{BoardInPost, Section, User},
-    utils::http_client,
+    types::{BoardInPost, Section, User, LoginInfo, Token},
     Board, Post, Reply,
+    utils::{request, http_client, read_input}
 };
 
 const GLOWFIC_API_V1: &str = "https://www.glowfic.com/api/v1";
@@ -26,12 +29,61 @@ pub struct GlowficError {
     message: String,
 }
 
+impl Token {
+    pub async fn get() -> Result<Self, Vec<GlowficError>> {
+        get_token().await
+    }
+
+    pub async fn validate(self: &Self) -> Result<bool, Box<dyn Error>> {
+        let response = request::<bool>(
+            "https://www.glowfic.com/api/v1/boards/",
+            None,
+            false,
+            Some(self.to_auth_header()?)
+        ).await?;
+    
+        Ok(response.status() == StatusCode::OK)
+    }
+
+    pub fn to_auth_header(self: &Self) -> Result<HeaderMap, InvalidHeaderValue> {
+        let mut headers = HeaderMap::with_capacity(1);
+        headers.insert("Authorization", HeaderValue::from_str(&format!("Basic {}", self.token))?);
+    
+        Ok(headers)
+    }
+}
+
+#[once]
+async fn get_token() -> Result<Token, Vec<GlowficError>> {
+    let login_info = LoginInfo::get().unwrap();
+
+    let form_data = vec![("username", &login_info.username), ("password", &login_info.password)];
+    let response: GlowficResponse<Token> = request(&format!("{GLOWFIC_API_V1}/login"), Some(&form_data), true, None).await.unwrap().json().await.unwrap();
+    
+    response.into_result()
+}
+
+impl LoginInfo {
+    pub fn get() -> Result<LoginInfo, io::Error> {
+        println!("Login Required: Please enter your username.");
+        let username = read_input()?;
+    
+        println!("Please enter your password.");
+        let password = read_input()?;
+        
+        Ok(LoginInfo {
+            username: username,
+            password: password
+        })
+    }
+}
+
 impl Board {
     pub fn url(id: u64) -> String {
         format!("{GLOWFIC_API_V1}/boards/{id}")
     }
 
-    pub async fn get(id: u64) -> Result<Result<Self, Vec<GlowficError>>, reqwest::Error> {
+    pub async fn get(id: u64) -> Result<Result<Self, Vec<GlowficError>>, Box<dyn Error>> {
         get_glowfic(&Self::url(id)).await
     }
 }
@@ -41,7 +93,7 @@ impl Post {
         format!("{GLOWFIC_API_V1}/posts/{id}")
     }
 
-    pub async fn get(id: u64) -> Result<Result<Self, Vec<GlowficError>>, reqwest::Error> {
+    pub async fn get(id: u64) -> Result<Result<Self, Vec<GlowficError>>, Box<dyn Error>> {
         get_glowfic(&Self::url(id)).await
     }
 }
@@ -56,11 +108,11 @@ impl Replies {
     async fn get_page(
         id: u64,
         page: u64,
-    ) -> Result<Result<Self, Vec<GlowficError>>, reqwest::Error> {
+    ) -> Result<Result<Self, Vec<GlowficError>>, Box<dyn Error>> {
         get_glowfic(&Self::page_url(id, page)).await
     }
 
-    pub async fn get_all(id: u64) -> Result<Result<Vec<Reply>, Vec<GlowficError>>, reqwest::Error> {
+    pub async fn get_all(id: u64) -> Result<Result<Vec<Reply>, Vec<GlowficError>>, Box<dyn Error>> {
         let mut replies = vec![];
 
         for page in 1.. {
@@ -115,13 +167,13 @@ impl BoardPosts {
     async fn get_page(
         id: u64,
         page: u64,
-    ) -> Result<Result<Self, Vec<GlowficError>>, reqwest::Error> {
+    ) -> Result<Result<Self, Vec<GlowficError>>, Box<dyn Error>> {
         get_glowfic::<Self>(&Self::page_url(id, page)).await
     }
 
     pub async fn get_all(
         id: u64,
-    ) -> Result<Result<Vec<PostInBoard>, Vec<GlowficError>>, reqwest::Error> {
+    ) -> Result<Result<Vec<PostInBoard>, Vec<GlowficError>>, Box<dyn Error>> {
         let mut posts = vec![];
 
         for page in 1.. {
@@ -144,13 +196,36 @@ impl BoardPosts {
 
 pub(crate) async fn get_glowfic<T>(
     url: &str,
-) -> Result<Result<T, Vec<GlowficError>>, reqwest::Error>
+) -> Result<Result<T, Vec<GlowficError>>, Box<dyn Error>>
 where
     T: DeserializeOwned,
 {
     let response = retry(5, || http_client().get(url).send()).await?;
-    let parsed: GlowficResponse<T> = response.json().await?;
+    let mut parsed: GlowficResponse<T> = response.json().await?;
+    
+    match &parsed {
+        GlowficResponse::Error { errors } => {
+            if errors.iter().any(|e| e.message == "You do not have permission to perform this action.") {
+                let token: Token;
+                match Token::get().await {
+                    Ok(t) => { token = t; },
+                    Err(e) => { return Ok(Err(e)); }
+                };
 
+                if token.validate().await? {
+                    let response = request::<bool>(
+                        url,
+                        None,
+                        false,
+                        Some(token.to_auth_header()?)
+                    ).await?;
+
+                    parsed = response.json().await?;
+                }
+            }
+        },
+        _ => {}
+    };
     Ok(parsed.into_result())
 }
 

--- a/src/api/tests/fixture_generation.rs
+++ b/src/api/tests/fixture_generation.rs
@@ -3,7 +3,7 @@ use std::{ops::Range, time::Duration};
 use rand::{distributions::Uniform, Rng};
 use serde_json::Value;
 
-use crate::{utils::request_get, Board, Post};
+use crate::{utils::http_client, Board, Post};
 
 use super::super::{BoardPosts, Replies};
 
@@ -69,7 +69,7 @@ pub async fn to_responses(urls: &[String]) -> Result<Vec<Value>> {
     let mut responses: Vec<Value> = vec![];
 
     for url in urls {
-        responses.push(request_get(url).await?.json().await?);
+        responses.push(http_client().get(url).send().await?.json().await?);
 
         tokio::time::sleep(Duration::from_millis(100)).await;
     }

--- a/src/api/tests/fixture_generation.rs
+++ b/src/api/tests/fixture_generation.rs
@@ -3,7 +3,7 @@ use std::{ops::Range, time::Duration};
 use rand::{distributions::Uniform, Rng};
 use serde_json::Value;
 
-use crate::{Board, Post};
+use crate::{utils::request_get, Board, Post};
 
 use super::super::{BoardPosts, Replies};
 
@@ -69,7 +69,7 @@ pub async fn to_responses(urls: &[String]) -> Result<Vec<Value>> {
     let mut responses: Vec<Value> = vec![];
 
     for url in urls {
-        responses.push(reqwest::get(url).await?.json().await?);
+        responses.push(request_get(url).await?.json().await?);
 
         tokio::time::sleep(Duration::from_millis(100)).await;
     }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,0 +1,56 @@
+use std::{io, sync::OnceLock};
+
+use crate::api::GlowficError;
+use crate::types::Token;
+
+static TOKEN: OnceLock<Token> = OnceLock::new();
+
+impl Token {
+    pub fn try_global() -> Option<Self> {
+        TOKEN.get().cloned()
+    }
+    pub async fn global_or_prompt(
+    ) -> io::Result<Result<Result<Self, Vec<GlowficError>>, reqwest::Error>> {
+        if let Some(token) = Self::try_global() {
+            return Ok(Ok(Ok(token)));
+        }
+
+        let token = Self::prompt_user().await;
+
+        match &token {
+            Err(e) => {
+                log::error!("Failed to retrieve user credentials: {e}.");
+            }
+            Ok(Err(e)) => {
+                log::error!("Connection error while fetching auth token: {e}");
+            }
+            Ok(Ok(Err(e))) => {
+                log::error!("Failed to fetch auth token: {e:?}");
+            }
+            Ok(Ok(Ok(token))) => {
+                log::info!("Setting token {}", &token.token);
+                drop(TOKEN.set(token.clone()));
+            }
+        }
+
+        token
+    }
+}
+impl Token {
+    async fn prompt_user() -> io::Result<Result<Result<Self, Vec<GlowficError>>, reqwest::Error>> {
+        pub fn read_input() -> io::Result<String> {
+            let mut buffer = String::new();
+            std::io::stdin().read_line(&mut buffer)?;
+            Ok(buffer.trim_end().to_string())
+        }
+
+        println!("Login Required.");
+        println!("Please enter your username:");
+        let username = read_input()?;
+
+        println!("Please enter your password:");
+        let password = read_input()?;
+
+        Ok(Self::get(&username, &password).await)
+    }
+}

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -48,8 +48,7 @@ impl Token {
         println!("Please enter your username:");
         let username = read_input()?;
 
-        println!("Please enter your password:");
-        let password = read_input()?;
+        let password = rpassword::prompt_password("Please enter your password: ")?;
 
         Ok(Self::get(&username, &password).await)
     }

--- a/src/cached.rs
+++ b/src/cached.rs
@@ -12,7 +12,9 @@ use serde::{de::DeserializeOwned, Serialize};
 use crate::{
     api::{BoardPosts, GlowficError, PostInBoard, Replies},
     types::{Continuity, Icon, Thread},
-    utils::{extension_to_image_mime, guess_image_mime, mime_to_image_extension, request_get, url_hash},
+    utils::{
+        extension_to_image_mime, guess_image_mime, http_client, mime_to_image_extension, url_hash,
+    },
     Board, Post, Reply,
 };
 
@@ -276,7 +278,7 @@ where
 }
 
 pub async fn download_image(url: &str) -> Result<(Mime, Vec<u8>), reqwest::Error> {
-    let response = request_get(url).await?;
+    let response = http_client().get(url).send().await?;
 
     let content_type = response.headers().get(CONTENT_TYPE).unwrap();
     let mime = Mime::from_str(content_type.to_str().unwrap()).unwrap();

--- a/src/cached.rs
+++ b/src/cached.rs
@@ -12,7 +12,7 @@ use serde::{de::DeserializeOwned, Serialize};
 use crate::{
     api::{BoardPosts, GlowficError, PostInBoard, Replies},
     types::{Continuity, Icon, Thread},
-    utils::{extension_to_image_mime, guess_image_mime, mime_to_image_extension, url_hash},
+    utils::{extension_to_image_mime, guess_image_mime, mime_to_image_extension, request_get, url_hash},
     Board, Post, Reply,
 };
 
@@ -276,7 +276,7 @@ where
 }
 
 pub async fn download_image(url: &str) -> Result<(Mime, Vec<u8>), reqwest::Error> {
-    let response = reqwest::get(url).await?;
+    let response = request_get(url).await?;
 
     let content_type = response.headers().get(CONTENT_TYPE).unwrap();
     let mime = Mime::from_str(content_type.to_str().unwrap()).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 mod rfc3339;
 
+mod auth;
+
 pub mod api;
 pub mod cached;
 pub mod gen;

--- a/src/types.rs
+++ b/src/types.rs
@@ -65,13 +65,6 @@ pub struct Token {
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct LoginInfo {
-    pub username: String,
-    pub password: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct BoardInPost {
     pub id: u64,
     pub name: String,

--- a/src/types.rs
+++ b/src/types.rs
@@ -59,6 +59,19 @@ pub struct User {
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
+pub struct Token {
+    pub token: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LoginInfo {
+    pub username: String,
+    pub password: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct BoardInPost {
     pub id: u64,
     pub name: String,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,9 +1,7 @@
-use std::{io::{Cursor, self, stdin}, str::FromStr, sync::OnceLock};
+use std::{io::Cursor, str::FromStr, sync::OnceLock};
 
 use image::io::Reader;
 use mime::Mime;
-use reqwest::{header::HeaderMap, Response};
-use serde::Serialize;
 use sha2::{Digest, Sha256};
 
 use crate::types::{Icon, Thread};
@@ -74,36 +72,11 @@ pub fn http_client() -> reqwest::Client {
         .clone()
 }
 
-pub async fn request<F>(
-    url: &str,
-    form_data: Option<&F>,
-    post: bool,
-    headers: Option<HeaderMap>,
-) -> reqwest::Result<Response>
-where
-    F: Serialize + ?Sized,
-{
-    let mut builder = if post {
-        http_client().post(url)
-    } else {
-        http_client().get(url)
-    };
-    match form_data {
-        Some(d) => {
-            builder = builder.form(d);
-        }
-        None => {}
-    }
-    match headers {
-        Some(h) => builder.headers(h),
-        None => builder,
-    }
-    .send()
-    .await
+pub trait AnyMap: Sized {
+    fn any_map<O>(self, f: impl FnOnce(Self) -> O) -> O;
 }
-
-pub fn read_input() -> Result<String, io::Error> {
-    let mut buffer = String::new();
-    stdin().read_line(&mut buffer)?;
-    Ok(buffer.trim_end().to_string())
+impl<T> AnyMap for T {
+    fn any_map<O>(self, f: impl FnOnce(Self) -> O) -> O {
+        f(self)
+    }
 }


### PR DESCRIPTION
> Implements the necessary interfaces to log in, when a post is otherwise unavailable.
>
> Also improves the handling of HTTP queries slightly, by using a cached HTTP client instead of recreating one for each request.
>
> Uses a different sort of cache for the login token, because saving it on-disk seemed unwise.
>
> I can recommend testing with https://glowfic.com/posts/8225, because it's a short, recent, safe-for-work members-only post.

Closes #34, original author (@Hate9) expressed preference for not force-pushing in previous PR.