### PR TITLE
Add `resize-icons` flag and feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ cargo run -- board 215
 
 - `--use-cache`: re-use already cached items.
 - `--jpeg`: convert images in epubs to jpeg, can lead to significantly smaller file sizes.
+- `--resize-icons`: downscale the icons in epubs to the specified width (e.g. `--resize-icons=250`) in pixels, or 100 pixels if unspecified.
 - `--text-to-speech`: change the output in a way that may be more comfortable for text-to-speech.
 - `--flatten-details`: flatten `details` tags (see example below).
   Valid values are `--flatten-details=none` (default), `--flatten-details=all`, `--flatten-details=mixed`. `mixed` flattens details in epubs only.

--- a/src/gen/epub.rs
+++ b/src/gen/epub.rs
@@ -19,7 +19,7 @@ use super::{
 
 impl Continuity {
     pub async fn to_epub(&self, options: Options) -> Result<Vec<u8>, Box<dyn Error>> {
-        let mut images_to_intern = self.images_to_intern().await?;
+        let mut images_to_intern = self.images_to_intern(options.resize_icons).await?;
 
         if options.jpeg {
             images_to_intern = images_to_intern
@@ -370,7 +370,7 @@ impl Thread {
 
 impl Thread {
     pub async fn to_epub(&self, options: Options) -> Result<Vec<u8>, Box<dyn Error>> {
-        let mut images_to_intern = self.images_to_intern().await?;
+        let mut images_to_intern = self.images_to_intern(options.resize_icons).await?;
 
         if options.jpeg {
             images_to_intern = images_to_intern

--- a/src/gen/epub.rs
+++ b/src/gen/epub.rs
@@ -19,7 +19,20 @@ use super::{
 
 impl Continuity {
     pub async fn to_epub(&self, options: Options) -> Result<Vec<u8>, Box<dyn Error>> {
-        let mut images_to_intern = self.images_to_intern(options.resize_icons).await?;
+        let mut images_to_intern = self.images_to_intern().await?;
+
+        if let Some(size) = options.resize_icons {
+            images_to_intern = images_to_intern
+                .into_iter()
+                .map(|(k, v)| {
+                    if v.is_icon() {
+                        Ok((k, v.resize_down(size)?))
+                    } else {
+                        Ok((k, v))
+                    }
+                })
+                .collect::<Result<_, Box<dyn Error>>>()?;
+        }
 
         if options.jpeg {
             images_to_intern = images_to_intern
@@ -370,7 +383,20 @@ impl Thread {
 
 impl Thread {
     pub async fn to_epub(&self, options: Options) -> Result<Vec<u8>, Box<dyn Error>> {
-        let mut images_to_intern = self.images_to_intern(options.resize_icons).await?;
+        let mut images_to_intern = self.images_to_intern().await?;
+
+        if let Some(size) = options.resize_icons {
+            images_to_intern = images_to_intern
+                .into_iter()
+                .map(|(k, v)| {
+                    if v.is_icon() {
+                        Ok((k, v.resize_down(size)?))
+                    } else {
+                        Ok((k, v))
+                    }
+                })
+                .collect::<Result<_, Box<dyn Error>>>()?;
+        }
 
         if options.jpeg {
             images_to_intern = images_to_intern

--- a/src/gen/mod.rs
+++ b/src/gen/mod.rs
@@ -20,6 +20,7 @@ pub struct Options {
     pub text_to_speech: bool,
     pub flatten_details: bool,
     pub jpeg: bool,
+    pub resize_icons: Option<u32>,
 }
 
 fn raw_title_page(post: &Post, reply_count: usize) -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,6 +68,12 @@ struct CliOptions {
     #[clap(long)]
     jpeg: bool,
 
+    /// When inlining icons into the epub file, this will scale all icon images above the provided width down to that width.
+    /// Defaults to "100" if no value is provided.
+    /// (Does not affect SVGs or non-icon images.)
+    #[clap(long)]
+    resize_icons: Option<Option<u32>>,
+
     /// Output epub file to the specified directory.
     #[clap(long)]
     output_dir: Option<PathBuf>,
@@ -95,8 +101,10 @@ async fn main() {
         text_to_speech,
         flatten_details,
         jpeg,
+        resize_icons,
         output_dir,
     } = command.options();
+    let resize_icons = resize_icons.map(|inner| inner.unwrap_or(100));
 
     let output_dir = output_dir.unwrap_or_else(|| PathBuf::from(DEFAULT_OUTPUT_DIR));
 
@@ -107,6 +115,7 @@ async fn main() {
             FlattenDetails::None => false,
         },
         jpeg,
+        resize_icons: resize_icons,
     };
     let html_options = Options {
         text_to_speech,
@@ -115,6 +124,7 @@ async fn main() {
             FlattenDetails::None | FlattenDetails::Mixed => false,
         },
         jpeg,
+        resize_icons: resize_icons,
     };
 
     match command {

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,7 +104,8 @@ async fn main() {
         resize_icons,
         output_dir,
     } = command.options();
-    let resize_icons = resize_icons.map(|inner| inner.unwrap_or(100));
+
+    let resize_icons = resize_icons.unwrap_or(Some(100));
 
     let output_dir = output_dir.unwrap_or_else(|| PathBuf::from(DEFAULT_OUTPUT_DIR));
 
@@ -115,7 +116,7 @@ async fn main() {
             FlattenDetails::None => false,
         },
         jpeg,
-        resize_icons: resize_icons,
+        resize_icons,
     };
     let html_options = Options {
         text_to_speech,
@@ -124,7 +125,7 @@ async fn main() {
             FlattenDetails::None | FlattenDetails::Mixed => false,
         },
         jpeg,
-        resize_icons: resize_icons,
+        resize_icons,
     };
 
     match command {


### PR DESCRIPTION
Adds an optional flag/argument to resize all icons above a certain width down to that width (defaulting to 100, because that's the maximum display-width for icons on glowfic.com).

This does not affect the cache, and does not interfere with the `--jpeg` flag.

Resolves #38.

I'm mostly very confident in the code quality on this one, with the sole exception that there *must* be a better way to handle default values for `Option<Option>` args, but if there is, I couldn't figure out what it was.

This feature required adding a parameter to several existing functions in `intern_images`, and so is a breaking change.