### PR TITLE
Fixed character aliases not being used

### DIFF
--- a/src/gen/mod.rs
+++ b/src/gen/mod.rs
@@ -142,7 +142,7 @@ fn content_block(
                 .map(|n| transform::escape_html(&n))
                 .unwrap_or_default();
             let character_name =
-                transform::escape_html(character_name.as_ref().unwrap_or(&character_default_name));
+                transform::escape_html(character_name.as_ref().unwrap_or(character_default_name));
 
             match author {
                 Some(User {

--- a/src/gen/mod.rs
+++ b/src/gen/mod.rs
@@ -97,6 +97,10 @@ impl Post {
             None,
             &None,
             &self.character,
+            &self
+                .character
+                .as_ref()
+                .map(|character| character.name.clone()),
             &self.icon,
             &self.content,
             options,
@@ -109,6 +113,7 @@ impl Reply {
             Some(self.id),
             &Some(self.user.clone()),
             &self.character,
+            &self.character_name,
             &self.icon,
             &self.content,
             options,
@@ -120,6 +125,7 @@ fn content_block(
     reply_id: Option<u64>,
     author: &Option<User>,
     character: &Option<Character>,
+    character_name: &Option<String>,
     icon: &Option<Icon>,
     content: &str,
     options: Options,
@@ -127,7 +133,7 @@ fn content_block(
     let caption = match character {
         Some(Character {
             id: character_id,
-            name: character_name,
+            name: character_default_name,
             screenname,
         }) => {
             let screenname = screenname
@@ -135,7 +141,8 @@ fn content_block(
                 .map(|n| format!("({n})"))
                 .map(|n| transform::escape_html(&n))
                 .unwrap_or_default();
-            let character_name = transform::escape_html(character_name);
+            let character_name =
+                transform::escape_html(character_name.as_ref().unwrap_or(&character_default_name));
 
             match author {
                 Some(User {

--- a/src/types.rs
+++ b/src/types.rs
@@ -91,6 +91,8 @@ pub struct Icon {
 pub struct Reply {
     pub id: u64,
     pub character: Option<Character>,
+    /// The name being used for this character in this reply.
+    /// This will be an alias if one was used, or else the same as `self.character.name`.
     pub character_name: Option<String>,
     pub content: String,
     #[serde(with = "crate::rfc3339")]


### PR DESCRIPTION
For some reason, we were keeping track of the character alias in each reply, but not using it. This PR fixes that.