### PR TITLE
Adds `--output-format` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,10 @@ cargo run -- board 215
   Valid values are `--flatten-details=none` (default), `--flatten-details=all`, `--flatten-details=mixed`. `mixed` flattens details in epubs only.
 - `--output-dir`: output files in this directory (e.g. `--output-dir=~/glowfic`).
   Note that this can flood the directory if used with `board` but without `--single-file`.
-- `--single-file`: if downloading a board/continuity, output the entire board in a single epub file.
+- `--output-format`: output files in a specific format (or `none` for a dry run).
+  Valid values are `--output-format=epub`, `--output-format=html`, `--output-format=both` (default), and `--output-format=none`.
+  Output file will be placed in format-specific subdirectories (e.g. `epub/` or `html/`) if `--output-format` is `both` or if `--output-dir` is unspecified.
+- `--single-file`: if downloading a board/continuity, output the entire board in a single epub file. Does not work with `--output-format=html`.
 
 ---
 


### PR DESCRIPTION
Adds an `--output-format` flag for determining which output files are created.

Defaults to `both` for backwards-compatibility.

Other supported values are `epub`, `html`, and `none` (to just download/cache files without generating any output files).