### PR TITLE
Moves dependencies and submodules behind Features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,15 +42,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "ammonia"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -902,7 +893,6 @@ dependencies = [
  "markup5ever_rcdom",
  "mime",
  "rand 0.8.5",
- "regex",
  "reqwest",
  "resvg",
  "rpassword",
@@ -2088,35 +2078,6 @@ checksum = "82b568323e98e49e2a0899dcee453dd679fae22d69adf9b11dd508d1549b7e2f"
 dependencies = [
  "bitflags 2.9.0",
 ]
-
-[[package]]
-name = "regex"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rend"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,42 +8,53 @@ repository = "https://github.com/QuartzLibrary/glowpub"
 readme = "README.md"
 edition = "2024"
 
+[features]
+default = ["binary"]
+binary = ["epub", "auth", "dep:clap", "dep:simple_logger", "dep:slug"]
+auth = ["api", "dep:rpassword", "dep:log"]
+epub = ["gen", "api", "dep:epub-builder", "dep:uuid"]
+api = ["types", "utils", "dep:serde_json", "dep:tokio", "dep:glob", "dep:log", "dep:rand"]
+gen = ["types", "utils", "dep:fontdb", "dep:resvg", "dep:textwrap", "dep:tiny-skia", "dep:usvg", "dep:ammonia", "dep:cssparser", "dep:html-escape", "dep:html5ever", "dep:lightningcss", "dep:lol_html", "dep:markup5ever", "dep:markup5ever_rcdom", "dep:xml5ever", "dep:log", "dep:rand"]
+types = ["dep:chrono", "dep:serde"]
+utils = ["dep:sha2", "dep:image", "dep:mime", "dep:reqwest"]
+
 [dependencies]
-chrono = { version = "0.4", features = ["serde"] }
-glob = "0.3"
-log = "0.4"
-mime = "0.3"
-rand = "0.8"
-regex = "1"
-sha2 = "0.10"
-uuid = { version = "1", features = ["v4"] }
+log = { version = "0.4", optional = true }
+rand = { version = "0.8", optional = true }
 
-reqwest = { version = "0.12", features = ["json"] }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-tokio = { version = "1", features = ["full"] }
+chrono = { version = "0.4", features = ["serde"], optional = true }
+serde = { version = "1", features = ["derive"], optional = true }
 
-fontdb = "0.16"
-resvg = "0.41"
-textwrap = "0.16"
-tiny-skia = "0.11"
-usvg = "0.41"
+mime = { version = "0.3", optional = true }
+sha2 = { version = "0.10", optional = true }
+reqwest = { version = "0.12", features = ["json"], optional = true }
+image = { version = "0.25", default-features = false, features = ["bmp", "gif", "jpeg", "png", "webp"], optional = true }
 
-epub-builder = { version = "0.7", default-features = false, features = ["libzip"] }
+serde_json = { version ="1", optional = true }
+tokio = { version = "1", features = ["full"], optional = true }
+glob = { version = "0.3", optional = true }
 
-ammonia = "4"
-cssparser = "0.33"
-html-escape = "0.2"
-html5ever = "0.27"
-lightningcss = "1.0.0-alpha.55"
-lol_html = "1"
-markup5ever = "0.12"
-markup5ever_rcdom = "0.3"
-xml5ever = "0.18"
+fontdb = { version = "0.16", optional = true }
+resvg = { version = "0.41", optional = true }
+textwrap = { version = "0.16", optional = true }
+tiny-skia = { version = "0.11", optional = true }
+usvg = { version = "0.41", optional = true }
 
-image = { version = "0.25", default-features = false, features = ["bmp", "gif", "jpeg", "png", "webp"] }
+ammonia = { version = "4", optional = true }
+cssparser = { version = "0.33", optional = true }
+html-escape = { version = "0.2", optional = true }
+html5ever = { version = "0.27", optional = true }
+lightningcss = { version = "1.0.0-alpha.55", optional = true }
+lol_html = { version = "1", optional = true }
+markup5ever = { version = "0.12", optional = true }
+markup5ever_rcdom = { version = "0.3", optional = true }
+xml5ever = { version = "0.18", optional = true }
 
-clap = { version = "4", features = ["derive"] }
-simple_logger = "4"
-slug = "0.1"
-rpassword = "7.3.1"
+epub-builder = { version = "0.7", default-features = false, features = ["libzip"], optional = true }
+uuid = { version = "1", features = ["v4"], optional = true }
+
+rpassword = { version = "7.3.1", optional = true }
+
+clap = { version = "4", features = ["derive"], optional = true }
+simple_logger = { version = "4", optional = true }
+slug = { version = "0.1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,29 +10,25 @@ edition = "2024"
 
 [features]
 default = ["binary"]
-binary = ["epub", "auth", "dep:clap", "dep:simple_logger", "dep:slug"]
-auth = ["api", "dep:rpassword", "dep:log"]
+binary = ["epub", "dep:clap", "dep:simple_logger", "dep:slug"]
 epub = ["gen", "api", "dep:epub-builder", "dep:uuid"]
-api = ["types", "utils", "dep:serde_json", "dep:tokio", "dep:glob", "dep:log", "dep:rand"]
-gen = ["types", "utils", "dep:fontdb", "dep:resvg", "dep:textwrap", "dep:tiny-skia", "dep:usvg", "dep:ammonia", "dep:cssparser", "dep:html-escape", "dep:html5ever", "dep:lightningcss", "dep:lol_html", "dep:markup5ever", "dep:markup5ever_rcdom", "dep:xml5ever", "dep:log", "dep:rand"]
-types = ["dep:chrono", "dep:serde"]
-utils = ["dep:sha2", "dep:image", "dep:mime", "dep:reqwest"]
+api = ["dep:serde_json", "dep:tokio", "dep:glob", "dep:rpassword"]
+gen = ["dep:fontdb", "dep:resvg", "dep:textwrap", "dep:tiny-skia", "dep:usvg", "dep:ammonia", "dep:cssparser", "dep:html-escape", "dep:html5ever", "dep:lightningcss", "dep:lol_html", "dep:markup5ever", "dep:markup5ever_rcdom", "dep:xml5ever"]
 
 [dependencies]
-log = { version = "0.4", optional = true }
-rand = { version = "0.8", optional = true }
-
-chrono = { version = "0.4", features = ["serde"], optional = true }
-serde = { version = "1", features = ["derive"], optional = true }
-
-mime = { version = "0.3", optional = true }
-sha2 = { version = "0.10", optional = true }
-reqwest = { version = "0.12", features = ["json"], optional = true }
-image = { version = "0.25", default-features = false, features = ["bmp", "gif", "jpeg", "png", "webp"], optional = true }
+log = "0.4"
+rand = "0.8"
+chrono = { version = "0.4", features = ["serde"] }
+serde = { version = "1", features = ["derive"] }
+mime = "0.3"
+sha2 = "0.10"
+reqwest = { version = "0.12", features = ["json"] }
+image = { version = "0.25", default-features = false, features = ["bmp", "gif", "jpeg", "png", "webp"] }
 
 serde_json = { version ="1", optional = true }
 tokio = { version = "1", features = ["full"], optional = true }
 glob = { version = "0.3", optional = true }
+rpassword = { version = "7.3.1", optional = true }
 
 fontdb = { version = "0.16", optional = true }
 resvg = { version = "0.41", optional = true }
@@ -52,8 +48,6 @@ xml5ever = { version = "0.18", optional = true }
 
 epub-builder = { version = "0.7", default-features = false, features = ["libzip"], optional = true }
 uuid = { version = "1", features = ["v4"], optional = true }
-
-rpassword = { version = "7.3.1", optional = true }
 
 clap = { version = "4", features = ["derive"], optional = true }
 simple_logger = { version = "4", optional = true }

--- a/src/cached.rs
+++ b/src/cached.rs
@@ -1,5 +1,4 @@
 use std::{
-    collections::BTreeSet,
     error::Error,
     path::{Path, PathBuf},
     str::FromStr,
@@ -17,6 +16,9 @@ use crate::{
         extension_to_image_mime, guess_image_mime, http_client, mime_to_image_extension, url_hash,
     },
 };
+
+#[cfg(feature = "gen")]
+use std::collections::BTreeSet;
 
 const CACHE_ROOT: &str = "./cache";
 

--- a/src/cached.rs
+++ b/src/cached.rs
@@ -162,6 +162,7 @@ impl Thread {
 
         Ok(Ok(Self { post, replies }))
     }
+    #[cfg(feature = "gen")]
     pub async fn cache_all_icons(&self, invalidate_cache: bool) {
         let icons: BTreeSet<_> = self.icons().collect();
 
@@ -205,6 +206,8 @@ impl Continuity {
 
         Ok(Ok(Self { board, threads }))
     }
+
+    #[cfg(feature = "gen")]
     pub async fn cache_all_icons(&self, invalidate_cache: bool) {
         let icons: BTreeSet<_> = self.threads.iter().flat_map(|t| t.icons()).collect();
         for icon in icons {

--- a/src/generate/mod.rs
+++ b/src/generate/mod.rs
@@ -1,5 +1,6 @@
 mod cover;
 
+#[cfg(feature = "epub")]
 pub mod epub;
 pub mod html;
 pub mod transform;

--- a/src/generate/mod.rs
+++ b/src/generate/mod.rs
@@ -1,4 +1,4 @@
-mod cover;
+pub mod cover;
 
 #[cfg(feature = "epub")]
 pub mod epub;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,21 @@
+#[cfg(any(feature = "api", feature = "types"))]
 mod rfc3339;
 
+#[cfg(feature = "auth")]
 mod auth;
 
+#[cfg(feature = "api")]
 pub mod api;
+#[cfg(feature = "api")]
 pub mod cached;
+#[cfg(feature = "gen")]
 pub mod generate;
+#[cfg(all(feature = "gen", feature = "api"))]
 pub mod intern_images;
+#[cfg(feature = "types")]
 pub mod types;
+#[cfg(feature = "utils")]
 pub mod utils;
 
+#[cfg(feature = "types")]
 pub use types::{Board, Post, Reply, Thread};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
-#[cfg(any(feature = "api", feature = "types"))]
 mod rfc3339;
 
-#[cfg(feature = "auth")]
+#[cfg(feature = "api")]
 mod auth;
 
 #[cfg(feature = "api")]
@@ -12,10 +11,7 @@ pub mod cached;
 pub mod generate;
 #[cfg(all(feature = "gen", feature = "api"))]
 pub mod intern_images;
-#[cfg(feature = "types")]
 pub mod types;
-#[cfg(feature = "utils")]
 pub mod utils;
 
-#[cfg(feature = "types")]
 pub use types::{Board, Post, Reply, Thread};

--- a/src/types.rs
+++ b/src/types.rs
@@ -104,15 +104,15 @@ pub struct Reply {
 }
 
 mod helpers {
-    use std::{
-        collections::{BTreeSet, HashSet},
-        iter,
-    };
-
-    #[cfg(feature = "gen")]
-    use crate::generate::transform;
+    use std::collections::BTreeSet;
 
     use super::*;
+
+    #[cfg(feature = "gen")]
+    use {
+        crate::generate::transform,
+        std::{collections::HashSet, iter},
+    };
 
     // TODO: can we rely on there always being at least one thread?
     impl Continuity {

--- a/src/types.rs
+++ b/src/types.rs
@@ -109,6 +109,7 @@ mod helpers {
         iter,
     };
 
+    #[cfg(feature = "gen")]
     use crate::generate::transform;
 
     use super::*;
@@ -156,6 +157,7 @@ mod helpers {
             (sections, sectionless_threads)
         }
     }
+    #[cfg(feature = "gen")]
     impl Thread {
         pub fn image_urls(&self) -> HashSet<String> {
             let contents = iter::once(&self.post.content)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,12 +4,10 @@ use image::ImageReader;
 use mime::Mime;
 use sha2::{Digest, Sha256};
 
-#[cfg(feature = "types")]
 use crate::types::{Icon, Thread};
 
 const USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),);
 
-#[cfg(feature = "types")]
 impl Thread {
     pub fn icons(&self) -> impl Iterator<Item = &Icon> {
         std::iter::once(self.post.icon.as_ref())

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,10 +4,12 @@ use image::ImageReader;
 use mime::Mime;
 use sha2::{Digest, Sha256};
 
+#[cfg(feature = "types")]
 use crate::types::{Icon, Thread};
 
 const USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),);
 
+#[cfg(feature = "types")]
 impl Thread {
     pub fn icons(&self) -> impl Iterator<Item = &Icon> {
         std::iter::once(self.post.icon.as_ref())


### PR DESCRIPTION
Glowpub is potentially quite useful as a library, but it has a *lot* of dependencies, which makes it a very large import if you only need a small subset of its functionality.

This PR moves everything behind Feature flags, so you can choose to import *only* the utils, or *only* the auth code, or even just the base types if you need those for whatever reason.

The `gen` flag could probably be split up into a few sub-features for independent submodules, but otherwise I think this PR works well.