### PR TITLE
Fixes the issue where permission errors would retry practically forever before asking for login

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -150,35 +150,31 @@ pub(crate) async fn get_glowfic<T>(
 where
     T: DeserializeOwned,
 {
-    let mut parsed: GlowficResponse<T> = retry(RETRIES, || async {
-        http_client()
+    let parsed: GlowficResponse<T> = retry(RETRIES, || async {
+        let mut response = http_client()
             .get(url)
             .any_map(|request| match Token::try_global() {
                 Some(token) => request.bearer_auth(token.token),
                 None => request,
             })
             .send()
-            .await?
-            .json()
-            .await
+            .await?;
+
+        if response.status() == reqwest::StatusCode::FORBIDDEN
+            && Token::try_global().is_none()
+            && let Ok(Ok(Ok(token))) = Token::global_or_prompt().await
+        {
+            response = http_client()
+                .get(url)
+                .bearer_auth(token.token)
+                .send()
+                .await?
+        }
+
+        response.error_for_status()?.json().await
     })
     .await?;
 
-    if parsed.is_permission_error() && Token::try_global().is_none() {
-        if let Ok(Ok(Ok(Token { token }))) = Token::global_or_prompt().await {
-            parsed = retry(RETRIES, || async {
-                http_client()
-                    .get(url)
-                    .bearer_auth(&token)
-                    .send()
-                    .await?
-                    .error_for_status()?
-                    .json()
-                    .await
-            })
-            .await?;
-        }
-    }
     Ok(parsed.into_result())
 }
 impl<T> GlowficResponse<T> {
@@ -190,14 +186,6 @@ impl<T> GlowficResponse<T> {
     }
 }
 
-impl<T> GlowficResponse<T> {
-    fn is_permission_error(&self) -> bool {
-        let Self::Error { errors } = self else {
-            return false;
-        };
-        errors.iter().any(|e| e.is_permission_error())
-    }
-}
 impl GlowficError {
     pub fn is_permission_error(&self) -> bool {
         self.message == "You do not have permission to perform this action."

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -150,7 +150,7 @@ pub(crate) async fn get_glowfic<T>(
 where
     T: DeserializeOwned,
 {
-    let parsed: GlowficResponse<T> = retry(RETRIES, || async {
+    let mut parsed: GlowficResponse<T> = retry(RETRIES, || async {
         http_client()
             .get(url)
             .any_map(|request| match Token::try_global() {
@@ -159,7 +159,6 @@ where
             })
             .send()
             .await?
-            .error_for_status()?
             .json()
             .await
     })
@@ -167,7 +166,7 @@ where
 
     if parsed.is_permission_error() && Token::try_global().is_none() {
         if let Ok(Ok(Ok(Token { token }))) = Token::global_or_prompt().await {
-            let parsed: GlowficResponse<T> = retry(RETRIES, || async {
+            parsed = retry(RETRIES, || async {
                 http_client()
                     .get(url)
                     .bearer_auth(&token)
@@ -178,14 +177,9 @@ where
                     .await
             })
             .await?;
-
-            Ok(parsed.into_result())
-        } else {
-            Ok(parsed.into_result())
         }
-    } else {
-        Ok(parsed.into_result())
     }
+    Ok(parsed.into_result())
 }
 impl<T> GlowficResponse<T> {
     fn into_result(self) -> Result<T, Vec<GlowficError>> {


### PR DESCRIPTION
Does what it says on the tin. Resolves #60.

Probably not the *best* solution, because it might make some errors very slightly less readable? But the errors in question are, by process of elimination, almost certainly the rate-limit triggering, so it's fine.

If you want to fix that problem, merge this first, *then* improve it. Glowpub is basically unusable for restricted-access threads as-is.

Also, removed a bit of redundancy in the get_glowfic() function while I was at it, because all those duplicate `Ok(parsed.into_result())`s were annoying me.